### PR TITLE
Use personal determiner when tying bundles

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -429,8 +429,8 @@ class LootProcess
       case bput('tap my bundle', 'You tap a \w+ bundle that you are wearing', 'I could not find what you were referring to')
       when /lumpy/
         if @tie_bundle
-          bput('tie bundle', 'TIE the bundle again')
-          bput('tie bundle', 'you tie the bundle')
+          bput('tie my bundle', 'TIE the bundle again')
+          bput('tie my bundle', 'you tie the bundle')
           bput('adjust bundle', 'You adjust')
         end
         game_state.need_bundle = false


### PR DESCRIPTION
This prevents the user from tying bundles which are on the ground, an issue reported by a user on LNet